### PR TITLE
Added an option to automatically install sample data package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ The first time you run this, Vagrant will download the bare Ubuntu box image. Th
 
 ## Customize
 When you change settings in the Vagrantfile, run `vagrant reload --provision` in order to update the settings. Feel free to make a pull request when you have improved something!
+
+If you want sample data installed as well, change sample_data="false" to sample_data="true" in Vagrantfile

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,6 @@
+# To install store sample data
+sample_data = "false"
+
 Vagrant.configure(2) do |config|
 
 	config.vm.box = "hashicorp/precise64"

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -86,7 +86,7 @@ fi
 
 echo "Install Magento CE"
 cd /vagrant/magento
-php -f install.php -- --license_agreement_accepted yes --locale "de_DE" --timezone "America/Phoenix" --default_currency EUR --db_host "127.0.0.1" --db_name magento --db_user magento_user --db_pass magento_pass --db_prefix "" --session_save "files" --admin_frontname "admin" --url "http://localhost/" --use_rewrites "yes" --use_secure "no" --secure_base_url "http://localhost/" --use_secure_admin "yes" --admin_firstname "Admin" --admin_lastname "Admin" --admin_email "admin.user@example.com" --admin_username "admin" --admin_password "admin123"
+php -f install.php -- --license_agreement_accepted yes --locale "de_DE" --timezone "America/Phoenix" --default_currency EUR --db_host "127.0.0.1" --db_name magento --db_user magento_user --db_pass magento_pass --db_prefix "" --session_save "files" --admin_frontname "admin" --url "http://localhost/" --use_rewrites "yes" --use_secure "no" --secure_base_url "http://localhost/" --use_secure_admin "yes" --admin_firstname "Admin" --admin_lastname "Admin" --admin_email "admin.user@example.com" --admin_username "admin" --admin_password "m123456789"
 
 echo "Adjust Base URLs"
 mysql -u root -p1234 -e "UPDATE magento.core_config_data set value ='http://127.0.0.1:4567/' where path like '%base_url%';"

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SAMPLE_DATA=$1
+
 echo "Provisioning virtual machine..."
 apt-get update > /dev/null
 
@@ -71,9 +73,20 @@ chmod -R 777 var/*
 chmod -R 777 media/*
 chmod 550 mage
 
+if [[ $SAMPLE_DATA == "true" ]]; then
+    echo "Importing sample data for Magento"
+    cd /vagrant/magento
+    wget https://raw.githubusercontent.com/Vinai/compressed-magento-sample-data/1.9.1.0/compressed-magento-sample-data-1.9.1.0.tgz > /dev/null
+    tar -xf compressed-magento-sample-data-1.9.1.0.tgz > /dev/null
+    cp -rv magento-sample-data-1.9.1.0/* ./
+    rm -f xvf compressed-magento-sample-data-1.9.1.0.tgz
+    rm -rf magento-sample-data-1.9.1.0/
+    mysql -uroot -p1234 magento < magento_sample_data_for_1.9.1.0.sql
+fi
+
 echo "Install Magento CE"
 cd /vagrant/magento
-php -f install.php -- --license_agreement_accepted yes --locale "de_DE" --timezone "America/Phoenix" --default_currency EUR --db_host "127.0.0.1" --db_name magento --db_user magento_user --db_pass magento_pass --db_prefix "" --session_save "files" --admin_frontname "admin" --url "http://localhost/" --use_rewrites "yes" --use_secure "no" --secure_base_url "http://localhost/" --use_secure_admin "yes" --admin_firstname "Admin" --admin_lastname "Admin" --admin_email "admin.user@example.com" --admin_username "admin" --admin_password "m123456789"
+php -f install.php -- --license_agreement_accepted yes --locale "de_DE" --timezone "America/Phoenix" --default_currency EUR --db_host "127.0.0.1" --db_name magento --db_user magento_user --db_pass magento_pass --db_prefix "" --session_save "files" --admin_frontname "admin" --url "http://localhost/" --use_rewrites "yes" --use_secure "no" --secure_base_url "http://localhost/" --use_secure_admin "yes" --admin_firstname "Admin" --admin_lastname "Admin" --admin_email "admin.user@example.com" --admin_username "admin" --admin_password "admin123"
 
 echo "Adjust Base URLs"
 mysql -u root -p1234 -e "UPDATE magento.core_config_data set value ='http://127.0.0.1:4567/' where path like '%base_url%';"


### PR DESCRIPTION
The setting can be controlled in Vagrantfile, setting sample_data to true or false
For approach regards to @rjbaker
If set to true, sample data would be downloaded from @Vinai 's repository with compressed package, and then unpacked.
